### PR TITLE
Docs: Reframe as feed-agnostic tool and surface priority contribution…

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,29 @@
+# Community Benchmarks
+
+Benchmark results from the community — which local model runs well on what hardware. Submit your own via a pull request.
+
+> **How to contribute:** Add a row to the table below with your hardware and results, then open a PR. See [CONTRIBUTING.md](CONTRIBUTING.md) for instructions.
+
+---
+
+## 🖥️ Benchmark Results
+
+| Machine | CPU | RAM | GPU / VRAM | OS | Model | Posts | Time | Notes |
+|---|---|---|---|---|---|---|---|---|
+| Lenovo ThinkPad P14s (20VX0068MZ) | Intel i7-1165G7 @ 2.80GHz | 16 GB | NVIDIA T500 — 4GB VRAM | Windows 11 | `llama3.2:latest` (3B) | 839 | ~25 min | Full VRAM fit, no RAM spill |
+| Lenovo ThinkPad P14s (20VX0068MZ) | Intel i7-1165G7 @ 2.80GHz | 16 GB | NVIDIA T500 — 4GB VRAM | Windows 11 | `mistral:latest` (7B) | 839 | Significantly longer | Partial RAM spill (model > VRAM) |
+
+---
+
+## 📋 Submission Template
+
+Copy and fill in the row below, then open a PR against `main`:
+
+```markdown
+| <Machine name/model> | <CPU> | <RAM> | <GPU + VRAM, or "CPU only"> | <OS> | `<model:tag>` | <post count> | <time> | <notes> |
+```
+
+**Tips:**
+- Run `nvidia-smi` (NVIDIA) or `rocm-smi` (AMD) to confirm GPU utilisation during inference.
+- Note whether the model fits entirely in VRAM or spills to RAM — this is the single biggest performance factor.
+- If running CPU-only, note the number of threads Ollama used (check `ollama ps`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,43 @@
 
 Thank you for your interest in contributing! This project is open source under the [MIT License](LICENSE). Contributions of all kinds are welcome — bug fixes, new features, documentation improvements, and new AI backend integrations.
 
+## 🎯 Priority Contribution Areas
+
+These are the contribution areas that would have the most impact on the project:
+
+### 1. New Data Sources
+X (Twitter) is just one chronological feed. The entire pipeline (fetch → rank → AI synthesis) is generic enough to support any source that produces a list of posts. High-value targets:
+- Reddit (top posts from subscribed subreddits)
+- Bluesky
+- RSS / Atom feeds
+- Telegram channels
+- Personal email newsletters
+
+See `fetch_timeline.py` for the existing fetching contract and `summarize.py` for the Markdown format the pipeline expects.
+
+### 2. Improving Local LLM Quality and Performance
+Local model inference is the most active area of improvement. Contributions welcome on:
+- Switching classification output to **JSON mode** (replacing fragile regex parsing)
+- **Async batching** of classification calls with `asyncio` for speed
+- **Dynamic category discovery** — letting the model propose the day's themes before classifying
+- Better prompt engineering for smaller models (3B–7B range)
+
+See `classify.py` and `intel_report.py`.
+
+### 3. New AI Backends
+The intelligence layer is designed to be extensible. Adding a new backend requires:
+1. A `generate_intel_report_<backend>(raw_summary_md: str) -> str` function in `intel_report.py`
+2. Registering it in the `generate_intel_report()` dispatcher
+3. Tests in `tests/test_intel_report.py`
+4. Documentation in the README
+
+Candidate backends: Anthropic Claude, local LlamaCpp, Mistral API, OpenAI.
+
+### 4. Hardware Benchmark Reports
+Knowing which local model runs well on what hardware is some of the most valuable community knowledge this project can accumulate. If you have tested a model on your own hardware, please **add a row to [BENCHMARKS.md](BENCHMARKS.md)**.
+
+No code required — just hardware specs + model + timing + notes.
+
 ---
 
 ## 🚀 Getting Started

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,13 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-X (Twitter) is a high-signal, high-noise environment. Following the right people means your timeline can surface critical geopolitical developments, market moves, and technology shifts — but extracting that signal requires scrolling, context-switching, and sustained attention across dozens of threads.
+Social feeds — X (Twitter), Bluesky, Reddit, RSS — are high-signal, high-noise environments. Following the right people means your feed can surface critical geopolitical developments, market moves, and technology shifts — but extracting that signal requires scrolling, context-switching, and sustained attention across dozens of threads.
 
-This tool replaces that process with a single daily document. It automatically reads your X home timeline, ranks posts by engagement, and uses a Large Language Model (LLM) to synthesize everything into a **strategic intelligence report** — structured by theme, stripped of noise, and ready to read in minutes.
+This tool replaces that process with a single daily document. It reads your feed, ranks posts by engagement, and uses a Large Language Model (LLM) to synthesize everything into a **strategic intelligence report** — structured by theme, stripped of noise, and ready to read in minutes.
 
 The goal is simple: **the important information, without the cognitive overhead.**
+
+Currently implemented for **X (Twitter)** via the official API. Extending to other feeds is a [priority contribution area](CONTRIBUTING.md).
 
 It generates two files:
 - **`summary_YYYY-MM-DD.md`** — Full ranked digest of the day's posts, grouped by author.
@@ -23,9 +25,10 @@ There are many existing Twitter summarization tools (e.g., *TwitterSummary, News
 
 **X Daily Summary Tool** was built for a different use case: **information consumers who value privacy and deep focus.**
 
-1. **Local Privacy:** It is optimized for 100% local, offline AI inference (Ollama + Llama 3.2). No third party ever sees your timeline, your reading habits, or your API keys.
-2. **Deep Reading:** It does not use a web dashboard or a chatbot interface. It generates a raw Markdown file on your own hard drive, designed for deep, undistracted reading. It treats your timeline like a serious daily intelligence briefing.
-3. **Algorithmic Independence:** It uses the official X API to fetch the raw, un-algorithmic `home_timeline`. It bypasses X's proprietary "For You" ranking and implements its own transparent, engagement-based ranking before feeding it to the AI.
+1. **Local Privacy:** Optimized for 100% local, offline AI inference (Ollama + Llama 3.2). No third party ever sees your feed, your reading habits, or your API keys.
+2. **Deep Reading:** No web dashboard or chatbot interface. Generates a raw Markdown file on your hard drive, designed for undistracted reading. Treats your feed like a serious daily intelligence briefing.
+3. **Algorithmic Independence:** Fetches the raw, chronological feed — bypassing platform ranking algorithms — and applies its own transparent, engagement-based ranking before feeding it to the AI.
+4. **Feed-Agnostic Architecture:** The pipeline (fetch → rank → synthesize) is designed to work with any source that produces a list of posts. X is today's implementation; Bluesky, Reddit, and RSS are natural next steps.
 
 ---
 
@@ -188,7 +191,7 @@ crontab -e
 
 ## 💻 Tested Hardware
 
-The local Ollama backend was successfully tested on the following setup:
+The Ollama local backend was first tested on this setup:
 
 | Component | Detail |
 |---|---|
@@ -198,19 +201,21 @@ The local Ollama backend was successfully tested on the following setup:
 | **GPU** | NVIDIA T500 — 4 GB VRAM (CUDA 12.8, Driver 573.57) |
 | **OS** | Windows 11, 64-bit |
 
-**GPU usage confirmed:** With `llama3.2:latest` (2GB), the entire model fits in the T500's 4GB VRAM — no CPU RAM spill. `nvidia-smi` confirms `ollama.exe` as the active GPU process during inference. You do **not** need to re-run any GPU configuration when switching between Ollama models — Ollama handles VRAM allocation automatically.
+**GPU usage confirmed:** With `llama3.2:latest` (2GB), the entire model fits in the T500's 4GB VRAM — no CPU RAM spill. `nvidia-smi` confirms `ollama.exe` as the active GPU process during inference. Ollama handles VRAM allocation automatically when switching models.
 
 **Generation speed:** ~25 minutes for a full 839-post run with Llama 3.2 (3B). Mistral 7B takes significantly longer due to partial RAM spill on this hardware.
+
+📊 **Running on different hardware?** Please contribute your benchmark results to [BENCHMARKS.md](BENCHMARKS.md) — just hardware specs, model name, post count, and timing.
 
 ---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- How to set up your local dev environment
-- Branching strategy and PR checklist
-- How to add a new AI backend
-- Code style guidelines
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. **Priority areas:**
+- 🌐 New data sources (Reddit, Bluesky, RSS, Telegram)
+- 🤖 Improving local LLM quality and performance
+- ➕ New AI backends (Claude, OpenAI, LlamaCpp, Mistral API)
+- 📊 Hardware benchmarks — add a row to [BENCHMARKS.md](BENCHMARKS.md)
 
 This project is licensed under the [MIT License](LICENSE).
 


### PR DESCRIPTION
… areas

- README intro: broaden from X-only to any social feed (X, Bluesky, Reddit, RSS)
- README Alternatives: add 4th differentiator 'Feed-Agnostic Architecture'
- README Contributing: list 4 priority areas and link to BENCHMARKS.md
- README Tested Hardware: add benchmark contribution CTA
- CONTRIBUTING.md: add Priority Contribution Areas section
- BENCHMARKS.md: new community benchmark table with submission template