### PR TITLE
Fail fast on Gemini/Ollama failures and return non-zero exit codes

### DIFF
--- a/intel_report.py
+++ b/intel_report.py
@@ -84,14 +84,19 @@ def _gemini_generate(client, model: str, contents: str):
 def _generate_gemini(prompt: str) -> str:
     api_key = os.getenv("GEMINI_API_KEY")
     if not api_key:
-        return "Error: GEMINI_API_KEY not set in .env"
+        raise RuntimeError("GEMINI_API_KEY not set in environment")
+
     client = genai.Client(api_key=api_key)
     model = os.getenv("GEMINI_MODEL", "gemini-flash-latest")
     try:
         response = _gemini_generate(client, model, prompt)
-        return response.text
     except Exception as e:
-        return f"Gemini error: {str(e)}"
+        raise RuntimeError(f"Gemini request failed: {e}") from e
+
+    text = getattr(response, "text", None)
+    if not text:
+        raise RuntimeError("Gemini returned an empty response")
+    return text
 
 
 # ─────────────────────────────────────────
@@ -108,9 +113,14 @@ def _generate_ollama(prompt: str) -> str:
             timeout=300,
         )
         response.raise_for_status()
-        return response.json().get("response", "")
+        payload = response.json()
     except Exception as e:
-        return f"Ollama error: {str(e)}"
+        raise RuntimeError(f"Ollama request failed: {e}") from e
+
+    text = payload.get("response", "")
+    if not text:
+        raise RuntimeError("Ollama returned an empty response")
+    return text
 
 
 # ─────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -227,12 +227,16 @@ def main():
     output_dir.mkdir(exist_ok=True)
     now = datetime.now(timezone.utc)
 
-    if args.from_cache is not None:
-        _, posts = _load_existing_cache(args.from_cache, output_dir, now)
-    else:
-        _, posts = _run_fetch_and_summarize(args, env_path, output_dir, now)
+    try:
+        if args.from_cache is not None:
+            _, posts = _load_existing_cache(args.from_cache, output_dir, now)
+        else:
+            _, posts = _run_fetch_and_summarize(args, env_path, output_dir, now)
 
-    _generate_and_save_intel_report(posts, now, output_dir, args.intel_limit, getattr(args, "intel_backend", None))
+        _generate_and_save_intel_report(posts, now, output_dir, args.intel_limit, getattr(args, "intel_backend", None))
+    except Exception as e:
+        print(f"[error] Run failed: {e}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
This PR fixes silent-success behavior when AI backends fail.

Previously, Gemini/Ollama errors were returned as plain strings and could be written into
`intel_report_*.md`, while the process still exited successfully. That made cron/CI think runs passed.

## Changes
- `intel_report.py`
  - `_generate_gemini()` now raises `RuntimeError` when:
    - `GEMINI_API_KEY` is missing
    - request fails
    - response is empty
  - `_generate_ollama()` now raises `RuntimeError` when:
    - request fails
    - response is empty

- `main.py`
  - Wrapped pipeline execution in `try/except`
  - On exception:
    - prints `[error] Run failed: ...`
    - exits with code `1`

## Why
- Correct failure semantics for automation (cron/CI/systemd)
- Prevents writing provider error text as if it were a valid report
- Makes backend errors explicit and actionable

## Validation
- `pytest -q`
- Result: `62 passed`